### PR TITLE
Hotfix: Erros na construção de OrganizationRepository

### DIFF
--- a/application/app/Infrastructure/EntityModels/OrganizationModel.php
+++ b/application/app/Infrastructure/EntityModels/OrganizationModel.php
@@ -29,9 +29,4 @@ class OrganizationModel extends AbstractModel
     protected $casts = [
         'status' => OrganizationStatusEnum::class . ':nullable',
     ];
-
-    public function owner(): BelongsTo
-    {
-        return $this->belongsTo(UserModel::class, 'owner_id', 'id');
-    }
 }

--- a/application/database/factories/Infrastructure/EntityModels/OrganizationModelFactory.php
+++ b/application/database/factories/Infrastructure/EntityModels/OrganizationModelFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories\Infrastructure\EntityModels;
 
 use App\Domain\Enums\OrganizationStatusEnum;
 use App\Infrastructure\EntityModels\OrganizationModel;
+use App\Infrastructure\EntityModels\UserModel;
 use Faker\Provider\pt_BR\Company;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\Enum\Laravel\Faker\FakerEnumProvider;
@@ -24,10 +25,13 @@ class OrganizationModelFactory extends Factory
      */
     public function definition(): array
     {
+        $owner = UserModel::factory()
+            ->create()
+            ->first();
         $this->faker->addProvider(new FakerEnumProvider($this->faker));
         $this->faker->addProvider(new Company($this->faker));
         return [
-            'owner_id' => $this->faker->uuid(),
+            'owner_id' => $owner->id,
             'corporate_name' => $this->faker->company() . ' LTDA',
             'fantasy_name' => $this->faker->company(),
             'logo_url' => $this->faker->imageUrl(),

--- a/application/database/migrations/2021_10_16_003616_create_organizations_table.php
+++ b/application/database/migrations/2021_10_16_003616_create_organizations_table.php
@@ -15,8 +15,11 @@ class CreateOrganizationsTable extends Migration
     public function up()
     {
         Schema::create('organizations', function (Blueprint $table) {
-            $table->uuid('id')->primary();
-            $table->uuid('owner_id');
+            $table->uuid('id')
+                ->primary();
+            $table->foreignUuid('owner_id')
+                ->references('id')
+                ->on('users');
             $table->string('corporate_name', 75);
             $table->string('fantasy_name', 75);
             $table->string('logo_url', 255);


### PR DESCRIPTION
Eu esqueci de alguns pontos enquanto desenvolvia a OrganizationRepository. Por exemplo, não defini o campo `owner_id` como chave estrangeira do campo `users.id`. Além disso, subi um método que acabei não precisando (`OrganizationModel->owner()`).