### PR TITLE
Feature: Adicionando relacionamento de gestores de Organização

### DIFF
--- a/application/tests/Unit/Domain/Repositories/OrganizationRepositoryTest.php
+++ b/application/tests/Unit/Domain/Repositories/OrganizationRepositoryTest.php
@@ -7,6 +7,7 @@ use App\Domain\Entities\User;
 use App\Domain\Repositories\OrganizationRepositoryInterface;
 use App\Infrastructure\EntityModels\OrganizationModel;
 use App\Infrastructure\EntityModels\UserModel;
+use Illuminate\Support\Collection;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 use Tests\TestCase;
 
@@ -42,7 +43,7 @@ class OrganizationRepositoryTest extends TestCase
      */
     public function shouldUpdateFromEntity(): void
     {
-        $model = OrganizationModel::factory()->create()->first();
+        $model = OrganizationModel::factory()->createOne();
         $entity = $model->getEntity();
         $entity->setFantasyName('Picpay');
         $entity = $this->repository->save($entity);
@@ -77,7 +78,7 @@ class OrganizationRepositoryTest extends TestCase
      */
     public function shouldDeleteWithSoftDelete(): void
     {
-        $entityModel = OrganizationModel::factory()->create()->first();
+        $entityModel = OrganizationModel::factory()->createOne();
         $deleted = $this->repository->delete($entityModel->id);
         self::assertTrue($deleted);
 
@@ -93,7 +94,7 @@ class OrganizationRepositoryTest extends TestCase
      */
     public function shouldRestoreTrashed(): void
     {
-        $model = OrganizationModel::factory()->create()->first();
+        $model = OrganizationModel::factory()->createOne();
         $deleted = $this->repository->delete($model->id);
         self::assertTrue($deleted);
 
@@ -106,14 +107,334 @@ class OrganizationRepositoryTest extends TestCase
 
     public function shouldFindOrganizationOwner(): void
     {
-        $user = UserModel::factory()->create()->first();
+        $user = UserModel::factory()->createOne();
         $model = OrganizationModel::factory([
             'owner_id' => $user->id,
-        ])->create()->first();
+        ])->createOne();
         $entity = $model->getEntity();
 
         $owner = $this->repository->findOwnerFrom($entity);
         self::assertInstanceOf(User::class, $owner);
         self::assertEquals($user->id, $owner->getId());
+    }
+
+    public function shouldAddOwnerAsOrganizationManager(): void
+    {
+        $user = UserModel::factory()->createOne();
+        $organization = OrganizationModel::factory([
+            'owner_id' => $user->id,
+        ])->createOne();
+        $relationships = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->id)
+            ->get();
+        self::assertCount(1, $relationships);
+        self::assertEquals($user->id, $relationships->first()->user_id);
+    }
+
+    public function shouldTransferOrganizationOwnership(): void
+    {
+        $user = UserModel::factory()->createOne();
+        $organization = OrganizationModel::factory([
+            'owner_id' => $user->id,
+        ])->createOne();
+        $entity = $organization->getEntity();
+        $newOwner = UserModel::factory()->createOne();
+
+        $this->repository->transferOwnership($entity, $newOwner->getEntity());
+
+        $owner = $this->repository->findOwnerFrom($entity);
+        self::assertEquals($newOwner->id, $owner->getId());
+
+        $relationships = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->id)
+            ->get();
+        self::assertCount(2, $relationships);
+        foreach ($relationships as $relationship) {
+            self::assertContains($relationship->user_id, [$user->id, $newOwner->id]);
+            self::assertEquals(OrganizationManagerStatusEnum::ACCEPTED(), $relationship->status);
+            // old owner keeps as admin
+            if ($relationship->user_id === $user->id) {
+                self::assertEquals(OrganizationManagerRolesEnum::ADMIN(), $relationship->role);
+            }
+        }
+    }
+
+    public function shouldNotTransferOrganizationOwnershipToTheCurrentOwner(): void
+    {
+        $user = UserModel::factory()->createOne();
+        $model = OrganizationModel::factory([
+            'owner_id' => $user->id,
+        ])->createOne();
+        $entity = $model->getEntity();
+
+        self::expectException(UserArealdyOwnsTheOrganizationException::class);
+        $this->repository->transferOwnership($entity, $user->getEntity());
+    }
+
+    public function shouldInviteOrganizationManagers(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+
+        $managersCount = 5;
+        $managers = UserModel::factory()->count($managersCount)->create();
+        foreach($managers as $manager) {
+            $this->repository->inviteManager(
+                $organization,
+                $manager->getEntity(),
+                OrganizationManagerRolesEnum::ADMIN()
+            );
+        }
+        $relationships = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->getId())
+            ->get();
+
+        self::assertEquals(
+            $managersCount + 1, // owner counts too
+            count($relationships)
+        );
+
+        foreach($relationships as $relationship) {
+            $expectedStatus = $relationship->user_id === $owner->id
+                ? OrganizationManagerStatusEnum::ACCEPTED()
+                : OrganizationManagerStatusEnum::INVITED();
+            self::assertEquals($expectedStatus, $relationship->status);
+        }
+    }
+
+    public function shouldNotListUnacceptedOrganizationManagers(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        /** @var Collection $managers */
+        $managers = $this->repository->findManagersFrom($organization);
+        self::assertCount(1, $managers);
+        self::assertEquals($owner->id, $managers->first()->getId());
+    }
+
+    public function shouldNotInviteTheOwner(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+
+        self::expectException(CannotInviteOrganizationOwnerException::class);
+
+        $this->repository->inviteManager(
+            $organization,
+            $owner->getEntity(),
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+    }
+
+    public function shouldNotInviteTheSameManagerMoreThanOnce(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        self::expectException(ManagerAlreadyInvitedException::class);
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+    }
+
+    public function shouldAcceptOrganizationManagerInvitation(): void
+    {
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory()
+            ->createOne()
+            ->getEntity();
+        /** @var User $manager */
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        $this->repository->acceptManager(
+            $organization,
+            $manager
+        );
+
+        $relationship = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->getId())
+            ->where('user_id', $manager->getId())
+            ->get()
+            ->first();
+        self::assertEquals(OrganizationManagerStatusEnum::ACCEPTED(), $relationship->status);
+    }
+
+    public function shouldRejectOrganizationManagerInvitation(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+        /** @var User $manager */
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        $this->repository->rejectManager(
+            $organization,
+            $manager
+        );
+
+        $relationship = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->getId())
+            ->where('user_id', $manager->getId())
+            ->get()
+            ->first();
+        self::assertEquals(OrganizationManagerStatusEnum::REJECTED(), $relationship->status);
+    }
+
+    public function shouldNotRejectAlreadyAcceptedOrganizationManagerInvitations(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+        /** @var User $manager */
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        $this->repository->acceptManager(
+            $organization,
+            $manager
+        );
+
+        self::expectException(InvitationAlreadyAcceptedException::class);
+        $this->repository->rejectManager(
+            $organization,
+            $manager
+        );
+    }
+
+    public function shouldRevokeOrganizationManager(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+        /** @var User $manager */
+        $manager = UserModel::factory()
+            ->createOne()
+            ->getEntity();
+
+        $this->repository->inviteManager(
+            $organization,
+            $manager,
+            OrganizationManagerRolesEnum::ADMIN()
+        );
+
+        $this->repository->revokeManager(
+            $organization,
+            $manager
+        );
+
+        $relationship = OrganizationManagerModel::query()
+            ->where('organization_id', $organization->getId())
+            ->where('user_id', $manager->getId())
+            ->get()
+            ->first();
+        self::assertEquals(OrganizationManagerStatusEnum::REVOKED(), $relationship->status);
+    }
+
+    public function shouldNotRevokeOrganizationOwner(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+
+        self::expectException(CannotRevokeOrganizationOwnerException::class);
+        $this->repository->revokeManager(
+            $organization,
+            $owner->getEntity()
+        );
+    }
+
+    public function shouldListAcceptedOrganizationManagers(): void
+    {
+        $owner = UserModel::factory()->createOne();
+        /** @var Organization $organization */
+        $organization = OrganizationModel::factory(['owner_id' => $owner->id])
+            ->createOne()
+            ->getEntity();
+
+        $managersCount = 5;
+        $users = UserModel::factory()->count($managersCount)->create();
+        $expectedUserIds = [$owner->id];
+        foreach($users as $user) {
+            $expectedUserIds[] = $user->id;
+            $manager = $user->getEntity();
+            $this->repository->inviteManager(
+                $organization,
+                $manager,
+                OrganizationManagerRolesEnum::ADMIN()
+            );
+            $this->repository->acceptManager(
+                $organization,
+                $manager
+            );
+        }
+        $managers = $this->repository->findManagersFrom($organization);
+        self::assertCount($managersCount + 1, $managers);
+        foreach($managers as $manager) {
+            self::assertContains($manager->getId(), $expectedUserIds);
+        }
     }
 }


### PR DESCRIPTION
# Ideia inicial

Para o relacionamento muitos para muitos, não irei criar uma nova entidade, apenas ampliar as possibilidades dos repositories das entidades existentes (`UserRepository` + `OrganizationRepository`).

Pretendo fazer:
- a partir da `UserRepository`, listar todas as organizações de um usuário, seja ele dono ou apenas administrador;
- a partir da `OrganizationRepository`:
    - listar todos os gestores;
    - convidar novo gestor;
    - aceitar convite;
    - recusar convite;
    - transferir organização (passar para novo dono);
    - desligar gestor.

Estou criando esse PR de antemão para ouvir opiniões sobre o desenvolvimento, principalmente no processo de TDD, que ajuda a enxergar como irei executar essas intenções antes de bolar a solução.

**Obs.: os testes estão quebrados. Faz parte do TDD, primeiro quebramos, depois solucionamos.**